### PR TITLE
emulator Android 24 works. screenshot doesn't

### DIFF
--- a/Dockerfile.in
+++ b/Dockerfile.in
@@ -41,6 +41,8 @@ RUN dpkg --add-architecture i386 \
   && apt-get -yq install libncurses5:i386 libstdc++6:i386 zlib1g:i386 --no-install-recommends \
   && apt-get clean
 
+# Annie added in an attempt to get screenshots
+
 # Android arguments
 ARG ANDROID_SDK_VERSION="24.4.1"
 

--- a/docker-accessibility-capture/docker-accessibility-capture-entrypoint.sh
+++ b/docker-accessibility-capture/docker-accessibility-capture-entrypoint.sh
@@ -4,14 +4,18 @@ ip=$(ifconfig  | grep 'inet addr:'| grep -v '127.0.0.1' | cut -d: -f2 | awk '{ p
 socat tcp-listen:$ANDROID_EMULATOR_PORT,bind=$ip,fork tcp:127.0.0.1:$ANDROID_EMULATOR_PORT &
 socat tcp-listen:$ADB_PORT,bind=$ip,fork tcp:127.0.0.1:$ADB_PORT &
 
+echo "update check 4"
+
 emulator64-arm -avd $ANDROID_EMULATOR_NAME \
                   -port $ANDROID_EMULATOR_PORT \
                   -no-boot-anim \
                   -no-window \
                   -no-audio \
-                  -no-snapshot-save \
-                  -gpu off &
-
+                  #-no-snapshot-save \
+                  -gpu off \
+				  -verbose \
+				  #-qemu -usbdevice tablet -vnc :0
+                  &
 adb wait-for-device
 adb devices
 adb logcat


### PR DESCRIPTION
screen capture doesn't work and gives error in logcat (android log data) of:

07-05 16:18:58.840    74    74 D gralloc : Registering a buffer in the process that created it. This may cause memory ordering problems.
07-05 16:18:58.841    74    74 E libEGL  : called unimplemented OpenGL ES API
07-05 16:18:58.841    74    74 E SurfaceFlinger: glCheckFramebufferStatusOES error 0
07-05 16:18:58.841    74    74 E SurfaceFlinger: got GL_FRAMEBUFFER_COMPLETE_OES error while taking screenshot